### PR TITLE
Add CA certificates to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 
 WORKDIR /tmp/adguard_exporter
 
-RUN apk --no-cache add git alpine-sdk
+RUN apk --no-cache add git alpine-sdk ca-certificates
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags '-s -w' -o adguard_exporter ./
 
@@ -12,6 +12,7 @@ FROM scratch
 LABEL name="adguard-exporter"
 
 WORKDIR /root
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /tmp/adguard_exporter/adguard_exporter adguard_exporter
 
 CMD ["./adguard_exporter"]


### PR DESCRIPTION
This resolves TLS errors which can be raised when using `adguard_protocol=https` and not `insecure_tls_skip_verify`. Those errors would look like:

```
An error has occurred during login to AdguardGet "https://adguard.example:443/control/status": tls: failed to verify certificate: x509: certificate signed by unknown authority
```