### PR TITLE
Add adguard_ip_addr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ docker run \
 -e 'adguard_username=admin' \
 -e 'adguard_password=mypassword' \
 -e 'adguard_port=' \ #optional if adguard is not using port 80 (http)/443 (https)
+-e 'adguard_ip_addr=' \ #optional if adguard has an IP address different from where hostname resolves (unusual)
 -e 'interval=10s' \
 -e 'log_limit=10000' \
 -e 'server_port=9617' \
@@ -117,6 +118,7 @@ services:
       - adguard_username=admin
       - adguard_password=/run/secrets/my-adguard-pass
       - adguard_port= #optional
+      - adguard_ip_addr= #optional
       - server_port=9617
       - interval=10s
       - log_limit=10000
@@ -150,6 +152,7 @@ services:
       - adguard_username=admin
       - adguard_password=/run/secrets/my-adguard-pass
       - adguard_port= #optional
+      - adguard_ip_addr= #optional
       - server_port=9617
       - interval=10s
       - log_limit=10000
@@ -222,6 +225,9 @@ scrape_configs:
 
 # Port to use to communicate with Adguard API
 -adguard_port string (optional)
+
+# IP address to use to communicate with Adguard API, if different from hostname
+-adguard_ip_addr string (optional)
 
 # Limit for the return log data
 -log_limit string (optional) (default "1000")

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -22,6 +22,7 @@ type Config struct {
 	AdguardUsername       string        `config:"adguard_username"`
 	AdguardPassword       string        `config:"adguard_password"`
 	AdguardPort           string        `config:"adguard_port"`
+	AdguardIpAddr         string        `config:"adguard_ip_addr"`
 	ServerPort            string        `config:"server_port"`
 	Interval              time.Duration `config:"interval"`
 	LogLimit              string        `config:"log_limit"`
@@ -37,6 +38,7 @@ func getDefaultConfig() *Config {
 		AdguardUsername:       "",
 		AdguardPassword:       "",
 		AdguardPort:           "80",
+		AdguardIpAddr:         "",
 		ServerPort:            "9617",
 		Interval:              10 * time.Second,
 		LogLimit:              "1000",

--- a/main.go
+++ b/main.go
@@ -26,14 +26,14 @@ func main() {
 
 	metrics.Init()
 
-	initAdguardClient(conf.AdguardProtocol, conf.AdguardHostname, conf.AdguardUsername, conf.AdguardPassword, conf.AdguardPort, conf.Interval, conf.LogLimit, conf.RDnsEnabled, conf.InsecureTLSSkipVerify)
+	initAdguardClient(conf.AdguardProtocol, conf.AdguardHostname, conf.AdguardUsername, conf.AdguardPassword, conf.AdguardPort, conf.Interval, conf.LogLimit, conf.RDnsEnabled, conf.InsecureTLSSkipVerify, conf.AdguardIpAddr)
 	initHttpServer(conf.ServerPort)
 
 	handleExitSignal()
 }
 
-func initAdguardClient(protocol, hostname, username, password, port string, interval time.Duration, logLimit string, rdnsenabled bool, insecuretls bool) {
-	client := adguard.NewClient(protocol, hostname, username, password, port, interval, logLimit, rdnsenabled, insecuretls)
+func initAdguardClient(protocol, hostname, username, password, port string, interval time.Duration, logLimit string, rdnsenabled bool, insecuretls bool, ipOverride string) {
+	client := adguard.NewClient(protocol, hostname, username, password, port, interval, logLimit, rdnsenabled, insecuretls, ipOverride)
 	go client.Scrape()
 }
 


### PR DESCRIPTION
This lets you specify a different IP address than the hostname resolves to for adguard. This is useful when you need the hostname to match (for SNI or virtual hosts) but that hostname does not resolve to an address, or the address it resolves to is not what you want it to be. You can actually specify a hostname here too, thanks to how `net.Dial` works.

I'd welcome any feedback; happy to change names etc if you'd like.

I'd also entirely understand if you'd prefer not to merge; I'm happy to maintain my fork. Equally I'm happy to pitch in more if you'd like more help (e.g. I might be interested in adding structured logging).